### PR TITLE
feat: add ETF asset type (server-determined)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -116,6 +116,7 @@ Defined in `src/types.ts`:
 - **Enums**: `Currency`, `Locale`, `AssetClass`, `AssetType`, `TransactionType`, `PortfolioType`
 - **Entities**: `User`, `AssetItem`, `Transaction`, `Portfolio`, `Valuation`
 - **Portfolio variants**: `OverallPortfolio`, `AssetClassPortfolio`, `AssetTypePortfolio`, `AssetItemPortfolio`
+- **Server-determined types**: `AssetType.ETF` is not user-selectable in the add form — it is assigned by the server. ETF behaves like Stock (equity, symbol-based, buy/sell/dividend).
 
 ## Key Patterns
 

--- a/src/features/asset-items/components/add-asset-item-form.tsx
+++ b/src/features/asset-items/components/add-asset-item-form.tsx
@@ -94,15 +94,17 @@ export default function AddAssetItemForm() {
 										</SelectValue>
 									</SelectTrigger>
 									<SelectContent className="rounded-xl">
-										{Object.values(AssetType).map((type) => (
-											<SelectItem
-												key={type}
-												value={type}
-												className="rounded-lg"
-											>
-												{displayAssetTypeText(type)}
-											</SelectItem>
-										))}
+										{Object.values(AssetType)
+											.filter((type) => type !== AssetType.ETF)
+											.map((type) => (
+												<SelectItem
+													key={type}
+													value={type}
+													className="rounded-lg"
+												>
+													{displayAssetTypeText(type)}
+												</SelectItem>
+											))}
 									</SelectContent>
 								</Select>
 								{fieldState.invalid && (

--- a/src/features/asset-items/lib/utils.ts
+++ b/src/features/asset-items/lib/utils.ts
@@ -9,11 +9,15 @@ export function isSchemeCodeInputSupported(assetType: AssetType) {
 }
 
 export function isSymbolInputSupported(assetType: AssetType) {
-	return assetType === AssetType.Stock;
+	return assetType === AssetType.Stock || assetType === AssetType.ETF;
 }
 
 export function isCurrencyInputSupported(assetType: AssetType) {
-	return assetType !== AssetType.MutualFund && assetType !== AssetType.Stock;
+	return (
+		assetType !== AssetType.MutualFund &&
+		assetType !== AssetType.Stock &&
+		assetType !== AssetType.ETF
+	);
 }
 
 export function getApplicableAssetClasses(assetType: AssetType) {
@@ -30,6 +34,7 @@ export function getApplicableAssetClasses(assetType: AssetType) {
 		case AssetType.MutualFund:
 			return [AssetClass.Equity, AssetClass.Debt, AssetClass.Commodities];
 		case AssetType.Stock:
+		case AssetType.ETF:
 			return [AssetClass.Equity];
 		default:
 			throw new Error(`Unsupported asset type: ${assetType}`);

--- a/src/features/transactions/components/transactions-table.tsx
+++ b/src/features/transactions/components/transactions-table.tsx
@@ -61,7 +61,10 @@ export default function TransactionsTable({
 	return (
 		<div className="mx-auto">
 			<div className="flex justify-end text-xl font-semibold items-center gap-x-2">
-				<Link to="/asset-items/$assetItemId/transactions/add" params={{ assetItemId: assetItem.id }}>
+				<Link
+					to="/asset-items/$assetItemId/transactions/add"
+					params={{ assetItemId: assetItem.id }}
+				>
 					<Button className="cursor-pointer" disabled={isFetching}>
 						<PlusIcon />
 						Add Transaction
@@ -166,7 +169,10 @@ function getColumns(assetItem: AssetItemPortfolio): ColumnDef<TableItem>[] {
 						assetItem={item.assetItem}
 						transaction={item}
 					/>
-					<Link to="/asset-items/$assetItemId/transactions/$transactionId/edit" params={{ assetItemId: assetItem.id, transactionId: item.id }}>
+					<Link
+						to="/asset-items/$assetItemId/transactions/$transactionId/edit"
+						params={{ assetItemId: assetItem.id, transactionId: item.id }}
+					>
 						<Button className="cursor-pointer">
 							<EditIcon />
 							Edit
@@ -183,6 +189,7 @@ function getColumns(assetItem: AssetItemPortfolio): ColumnDef<TableItem>[] {
 function shouldShowUnitsColumn(assetItem: AssetItemPortfolio) {
 	return (
 		assetItem.assetType === AssetType.MutualFund ||
-		assetItem.assetType === AssetType.Stock
+		assetItem.assetType === AssetType.Stock ||
+		assetItem.assetType === AssetType.ETF
 	);
 }

--- a/src/features/transactions/lib/utils.ts
+++ b/src/features/transactions/lib/utils.ts
@@ -18,6 +18,7 @@ export function getApplicableTransactionTypes(
 		case AssetType.MutualFund:
 			return [TransactionType.Buy, TransactionType.Sell];
 		case AssetType.Stock:
+		case AssetType.ETF:
 			return [
 				TransactionType.Buy,
 				TransactionType.Sell,
@@ -82,6 +83,7 @@ export function getUnitLabelText(
 		case AssetType.MutualFund:
 			return "Units";
 		case AssetType.Stock:
+		case AssetType.ETF:
 			return transactionType === TransactionType.Dividend
 				? getAmountLabelText(assetItem)
 				: "Shares";

--- a/src/lib/utils.ts
+++ b/src/lib/utils.ts
@@ -48,6 +48,8 @@ export function displayAssetTypeText(assetType: AssetType) {
 			return "Mutual Fund";
 		case AssetType.Stock:
 			return "Stock";
+		case AssetType.ETF:
+			return "ETF";
 		case AssetType.Bond:
 			return "Bond";
 		default:

--- a/src/types.ts
+++ b/src/types.ts
@@ -25,6 +25,7 @@ export enum AssetType {
 	PPF = "PPF",
 	MutualFund = "MutualFund",
 	Stock = "Stock",
+	ETF = "ETF",
 	Bond = "Bond",
 }
 


### PR DESCRIPTION
Add ETF to the AssetType enum. ETF behaves like Stock (equity class, symbol-based, buy/sell/dividend transactions, shows units column).

ETF is excluded from the add asset item form dropdown since the type is determined by the server when processing stock asset items.