### PR TITLE
feat: add edit asset item page

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -104,6 +104,7 @@ src/
 | `/asset-items`                                              | `src/routes/asset-items/index.tsx`                                        |
 | `/asset-items/add`                                          | `src/routes/asset-items/add.tsx`                                          |
 | `/asset-items/:assetItemId`                                 | `src/routes/asset-items/$assetItemId.index.tsx`                           |
+| `/asset-items/:assetItemId/edit`                             | `src/routes/asset-items/$assetItemId.edit.tsx`                            |
 | `/asset-items/:assetItemId/transactions/add`                | `src/routes/asset-items/$assetItemId.transactions.add.tsx`                |
 | `/asset-items/:assetItemId/transactions/:transactionId/edit`| `src/routes/asset-items/$assetItemId.transactions.$transactionId.edit.tsx` |
 | `/portfolio`                                                | `src/routes/portfolio/index.tsx`                                          |
@@ -138,7 +139,7 @@ Available HOCs: `withAssetItems`, `withCurrency`, `withValuations`, `withAssetIt
 ### React Query Hooks
 
 Each feature has its own hooks file exporting query/mutation hooks:
-- `src/features/asset-items/hooks/asset-items.ts` — `useAllAssetItemsQuery`, `useAddAssetItemMutation`, `useDeleteAssetItemMutation`, `refreshAssetItems`, `refreshAssetItem`
+- `src/features/asset-items/hooks/asset-items.ts` — `useAllAssetItemsQuery`, `useAddAssetItemMutation`, `useEditAssetItemMutation`, `useDeleteAssetItemMutation`, `refreshAssetItems`, `refreshAssetItem`
 - `src/features/transactions/hooks/transactions.ts` — `useAssetItemTransactionsQuery`, `useTransactionQuery`, `useAddTransactionMutation`, `useEditTransactionMutation`, `useDeleteTransactionMutation`
 - `src/features/portfolio/hooks/valuations.ts` — `useValuationsQueries` (default export, uses `useQueries` for parallel fetching)
 

--- a/src/features/asset-items/components/asset-items-table.tsx
+++ b/src/features/asset-items/components/asset-items-table.tsx
@@ -1,6 +1,9 @@
+import { Link } from "@tanstack/react-router";
 import type { ColumnDef } from "@tanstack/react-table";
+import { EditIcon } from "lucide-react";
 
 import CurrencyAmount from "@/components/currency-amount";
+import { Button } from "@/components/ui/button";
 import { createColumnDef, DataTable } from "@/components/ui/data-table";
 import DeleteAssetItemDialog from "@/features/asset-items/components/delete-asset-item-dialog";
 import {
@@ -75,7 +78,20 @@ const columns: ColumnDef<AssetItemPortfolio>[] = [
 		id: "actions",
 		cell: ({ row }) => {
 			const item = row.original;
-			return <DeleteAssetItemDialog assetItem={item} />;
+			return (
+				<div className="flex gap-x-2 justify-center">
+					<Link
+						to="/asset-items/$assetItemId/edit"
+						params={{ assetItemId: item.id }}
+					>
+						<Button className="cursor-pointer">
+							<EditIcon />
+							Edit
+						</Button>
+					</Link>
+					<DeleteAssetItemDialog assetItem={item} />
+				</div>
+			);
 		},
 	},
 ];

--- a/src/features/asset-items/components/delete-asset-item-dialog.tsx
+++ b/src/features/asset-items/components/delete-asset-item-dialog.tsx
@@ -1,5 +1,5 @@
+import { Trash2Icon } from "lucide-react";
 import type React from "react";
-
 import CurrencyAmount from "@/components/currency-amount";
 import {
 	AlertDialog,
@@ -37,6 +37,7 @@ export default function DeleteAssetItemDialog({
 					buttonVariants({ variant: "destructive" }),
 				)}
 			>
+				<Trash2Icon />
 				Delete
 			</AlertDialogTrigger>
 			<AlertDialogContent>

--- a/src/features/asset-items/components/edit-asset-item-form.tsx
+++ b/src/features/asset-items/components/edit-asset-item-form.tsx
@@ -1,0 +1,79 @@
+import { zodResolver } from "@hookform/resolvers/zod";
+import { useRouter } from "@tanstack/react-router";
+import { Controller, useForm } from "react-hook-form";
+import type { z } from "zod";
+
+import { Button } from "@/components/ui/button";
+import { CardContent } from "@/components/ui/card";
+import {
+	Field,
+	FieldError,
+	FieldGroup,
+	FieldLabel,
+} from "@/components/ui/field";
+import { Input } from "@/components/ui/input";
+import { useEditAssetItemMutation } from "@/features/asset-items/hooks/asset-items";
+import {
+	type EditAssetItemRequest,
+	EditAssetItemSchema,
+} from "@/features/asset-items/schema";
+import type { AssetItem } from "@/types";
+
+export default function EditAssetItemForm({
+	assetItem,
+}: {
+	assetItem: AssetItem;
+}) {
+	const { mutateAsync: editAssetItemAsync } = useEditAssetItemMutation();
+	const router = useRouter();
+
+	const form = useForm<z.infer<typeof EditAssetItemSchema>>({
+		resolver: zodResolver(EditAssetItemSchema),
+		defaultValues: {
+			name: assetItem.name,
+		},
+	});
+
+	async function onSubmit(data: Omit<EditAssetItemRequest, "assetItemId">) {
+		await editAssetItemAsync({
+			...data,
+			assetItemId: assetItem.id,
+		});
+		router.history.back();
+	}
+
+	return (
+		<CardContent className="p-0">
+			<form onSubmit={form.handleSubmit(onSubmit)} className="flex flex-col">
+				<FieldGroup>
+					<Controller
+						control={form.control}
+						name="name"
+						render={({ field, fieldState }) => (
+							<Field data-invalid={fieldState.invalid}>
+								<FieldLabel>Asset Item Name</FieldLabel>
+								<Input
+									{...field}
+									id={field.name}
+									aria-invalid={fieldState.invalid}
+								/>
+								{fieldState.invalid && (
+									<FieldError errors={[fieldState.error]} />
+								)}
+							</Field>
+						)}
+					/>
+					<div className="flex justify-end">
+						<Button
+							type="submit"
+							className="cursor-pointer"
+							disabled={!form.formState.isDirty || form.formState.isSubmitting}
+						>
+							Save
+						</Button>
+					</div>
+				</FieldGroup>
+			</form>
+		</CardContent>
+	);
+}

--- a/src/features/asset-items/hooks/asset-items.ts
+++ b/src/features/asset-items/hooks/asset-items.ts
@@ -6,7 +6,10 @@ import {
 	useQueryClient,
 } from "@tanstack/react-query";
 import _ from "lodash";
-import type { AddAssetItemRequest } from "@/features/asset-items/schema";
+import type {
+	AddAssetItemRequest,
+	EditAssetItemRequest,
+} from "@/features/asset-items/schema";
 import { usePrimalApiClient } from "@/hooks/use-primal-api-client";
 import { type AssetItem, AssetType } from "@/types";
 
@@ -68,6 +71,23 @@ export function useDeleteAssetItemMutation() {
 			});
 
 			await refreshAssetItems(queryClient);
+		},
+	});
+}
+
+export function useEditAssetItemMutation() {
+	const queryClient = useQueryClient();
+	const primalApiClient = usePrimalApiClient();
+
+	return useMutation({
+		mutationFn: async ({ assetItemId, ...data }: EditAssetItemRequest) => {
+			await primalApiClient.patch(`asset-items/${assetItemId}`, data);
+		},
+		onSuccess: async (_data, { assetItemId }) => {
+			await refreshAssetItem(queryClient, { assetItemId });
+			await queryClient.invalidateQueries({
+				queryKey: ["assetitems", "all"],
+			});
 		},
 	});
 }

--- a/src/features/asset-items/schema.ts
+++ b/src/features/asset-items/schema.ts
@@ -8,6 +8,13 @@ import {
 import { AssetClass, AssetType, Currency } from "@/types";
 
 export type AddAssetItemRequest = z.infer<typeof AddAssetItemSchema>;
+export type EditAssetItemRequest = z.infer<typeof EditAssetItemSchema> & {
+	assetItemId: string;
+};
+
+export const EditAssetItemSchema = z.object({
+	name: z.string().min(3).max(50),
+});
 
 export const AddAssetItemSchema = z
 	.object({

--- a/src/routeTree.gen.ts
+++ b/src/routeTree.gen.ts
@@ -15,6 +15,7 @@ import { Route as PortfolioTrendsIndexRouteImport } from './routes/portfolio-tre
 import { Route as AssetItemsIndexRouteImport } from './routes/asset-items/index'
 import { Route as AssetItemsAddRouteImport } from './routes/asset-items/add'
 import { Route as AssetItemsAssetItemIdIndexRouteImport } from './routes/asset-items/$assetItemId.index'
+import { Route as AssetItemsAssetItemIdEditRouteImport } from './routes/asset-items/$assetItemId.edit'
 import { Route as AssetItemsAssetItemIdTransactionsAddRouteImport } from './routes/asset-items/$assetItemId.transactions.add'
 import { Route as AssetItemsAssetItemIdTransactionsTransactionIdEditRouteImport } from './routes/asset-items/$assetItemId.transactions.$transactionId.edit'
 
@@ -49,6 +50,12 @@ const AssetItemsAssetItemIdIndexRoute =
     path: '/asset-items/$assetItemId/',
     getParentRoute: () => rootRouteImport,
   } as any)
+const AssetItemsAssetItemIdEditRoute =
+  AssetItemsAssetItemIdEditRouteImport.update({
+    id: '/asset-items/$assetItemId/edit',
+    path: '/asset-items/$assetItemId/edit',
+    getParentRoute: () => rootRouteImport,
+  } as any)
 const AssetItemsAssetItemIdTransactionsAddRoute =
   AssetItemsAssetItemIdTransactionsAddRouteImport.update({
     id: '/asset-items/$assetItemId/transactions/add',
@@ -68,6 +75,7 @@ export interface FileRoutesByFullPath {
   '/asset-items/': typeof AssetItemsIndexRoute
   '/portfolio-trends/': typeof PortfolioTrendsIndexRoute
   '/portfolio/': typeof PortfolioIndexRoute
+  '/asset-items/$assetItemId/edit': typeof AssetItemsAssetItemIdEditRoute
   '/asset-items/$assetItemId/': typeof AssetItemsAssetItemIdIndexRoute
   '/asset-items/$assetItemId/transactions/add': typeof AssetItemsAssetItemIdTransactionsAddRoute
   '/asset-items/$assetItemId/transactions/$transactionId/edit': typeof AssetItemsAssetItemIdTransactionsTransactionIdEditRoute
@@ -78,6 +86,7 @@ export interface FileRoutesByTo {
   '/asset-items': typeof AssetItemsIndexRoute
   '/portfolio-trends': typeof PortfolioTrendsIndexRoute
   '/portfolio': typeof PortfolioIndexRoute
+  '/asset-items/$assetItemId/edit': typeof AssetItemsAssetItemIdEditRoute
   '/asset-items/$assetItemId': typeof AssetItemsAssetItemIdIndexRoute
   '/asset-items/$assetItemId/transactions/add': typeof AssetItemsAssetItemIdTransactionsAddRoute
   '/asset-items/$assetItemId/transactions/$transactionId/edit': typeof AssetItemsAssetItemIdTransactionsTransactionIdEditRoute
@@ -89,6 +98,7 @@ export interface FileRoutesById {
   '/asset-items/': typeof AssetItemsIndexRoute
   '/portfolio-trends/': typeof PortfolioTrendsIndexRoute
   '/portfolio/': typeof PortfolioIndexRoute
+  '/asset-items/$assetItemId/edit': typeof AssetItemsAssetItemIdEditRoute
   '/asset-items/$assetItemId/': typeof AssetItemsAssetItemIdIndexRoute
   '/asset-items/$assetItemId/transactions/add': typeof AssetItemsAssetItemIdTransactionsAddRoute
   '/asset-items/$assetItemId/transactions/$transactionId/edit': typeof AssetItemsAssetItemIdTransactionsTransactionIdEditRoute
@@ -101,6 +111,7 @@ export interface FileRouteTypes {
     | '/asset-items/'
     | '/portfolio-trends/'
     | '/portfolio/'
+    | '/asset-items/$assetItemId/edit'
     | '/asset-items/$assetItemId/'
     | '/asset-items/$assetItemId/transactions/add'
     | '/asset-items/$assetItemId/transactions/$transactionId/edit'
@@ -111,6 +122,7 @@ export interface FileRouteTypes {
     | '/asset-items'
     | '/portfolio-trends'
     | '/portfolio'
+    | '/asset-items/$assetItemId/edit'
     | '/asset-items/$assetItemId'
     | '/asset-items/$assetItemId/transactions/add'
     | '/asset-items/$assetItemId/transactions/$transactionId/edit'
@@ -121,6 +133,7 @@ export interface FileRouteTypes {
     | '/asset-items/'
     | '/portfolio-trends/'
     | '/portfolio/'
+    | '/asset-items/$assetItemId/edit'
     | '/asset-items/$assetItemId/'
     | '/asset-items/$assetItemId/transactions/add'
     | '/asset-items/$assetItemId/transactions/$transactionId/edit'
@@ -132,6 +145,7 @@ export interface RootRouteChildren {
   AssetItemsIndexRoute: typeof AssetItemsIndexRoute
   PortfolioTrendsIndexRoute: typeof PortfolioTrendsIndexRoute
   PortfolioIndexRoute: typeof PortfolioIndexRoute
+  AssetItemsAssetItemIdEditRoute: typeof AssetItemsAssetItemIdEditRoute
   AssetItemsAssetItemIdIndexRoute: typeof AssetItemsAssetItemIdIndexRoute
   AssetItemsAssetItemIdTransactionsAddRoute: typeof AssetItemsAssetItemIdTransactionsAddRoute
   AssetItemsAssetItemIdTransactionsTransactionIdEditRoute: typeof AssetItemsAssetItemIdTransactionsTransactionIdEditRoute
@@ -181,6 +195,13 @@ declare module '@tanstack/react-router' {
       preLoaderRoute: typeof AssetItemsAssetItemIdIndexRouteImport
       parentRoute: typeof rootRouteImport
     }
+    '/asset-items/$assetItemId/edit': {
+      id: '/asset-items/$assetItemId/edit'
+      path: '/asset-items/$assetItemId/edit'
+      fullPath: '/asset-items/$assetItemId/edit'
+      preLoaderRoute: typeof AssetItemsAssetItemIdEditRouteImport
+      parentRoute: typeof rootRouteImport
+    }
     '/asset-items/$assetItemId/transactions/add': {
       id: '/asset-items/$assetItemId/transactions/add'
       path: '/asset-items/$assetItemId/transactions/add'
@@ -204,6 +225,7 @@ const rootRouteChildren: RootRouteChildren = {
   AssetItemsIndexRoute: AssetItemsIndexRoute,
   PortfolioTrendsIndexRoute: PortfolioTrendsIndexRoute,
   PortfolioIndexRoute: PortfolioIndexRoute,
+  AssetItemsAssetItemIdEditRoute: AssetItemsAssetItemIdEditRoute,
   AssetItemsAssetItemIdIndexRoute: AssetItemsAssetItemIdIndexRoute,
   AssetItemsAssetItemIdTransactionsAddRoute:
     AssetItemsAssetItemIdTransactionsAddRoute,

--- a/src/routes/asset-items/$assetItemId.edit.tsx
+++ b/src/routes/asset-items/$assetItemId.edit.tsx
@@ -1,0 +1,52 @@
+import { createFileRoute } from "@tanstack/react-router";
+import SidebarTriggerWithBreadcrumb from "@/components/sidebar-trigger-with-breadcrumb";
+import { Card } from "@/components/ui/card";
+import EditAssetItemForm from "@/features/asset-items/components/edit-asset-item-form";
+import withAssetItems from "@/features/asset-items/hoc/with-asset-items";
+import type { AssetItem } from "@/types";
+
+export const Route = createFileRoute("/asset-items/$assetItemId/edit")({
+	component: EditAssetItemRoute,
+});
+
+function EditAssetItemRoute() {
+	const { assetItemId } = Route.useParams();
+	const WrappedComponent = withAssetItems(EditAssetItemContent);
+	return <WrappedComponent assetItemId={assetItemId} />;
+}
+
+function EditAssetItemContent({
+	assetItems,
+	assetItemId,
+}: {
+	assetItems: AssetItem[];
+	assetItemId: string;
+}) {
+	const assetItem = assetItems.find((item) => item.id === assetItemId);
+
+	if (!assetItem) {
+		return <div>Asset item not found</div>;
+	}
+
+	return (
+		<>
+			<title>Edit {assetItem.name}</title>
+			<SidebarTriggerWithBreadcrumb
+				breadcrumbs={[
+					{ title: "Asset Items", href: "/asset-items" },
+					{ title: assetItem.name, href: `/asset-items/${assetItemId}` },
+					{
+						title: "Edit",
+						href: `/asset-items/${assetItemId}/edit`,
+						disabled: true,
+					},
+				]}
+			/>
+			<div className="container mx-auto p-2 h-full">
+				<Card className="p-8 max-w-screen-sm mx-auto">
+					<EditAssetItemForm assetItem={assetItem} />
+				</Card>
+			</div>
+		</>
+	);
+}


### PR DESCRIPTION
Add a new route /asset-items/:assetItemId/edit with a form to edit the asset item name. Includes:
- EditAssetItemSchema (zod, name field 3-50 chars)
- useEditAssetItemMutation (PATCH asset-items/:id)
- EditAssetItemForm component
- Edit button in asset items table actions column (matching transactions table pattern)
- Trash icon added to delete button for consistency
- AGENTS.md updated with new route and hook